### PR TITLE
Add default_queue and default_maxMemory to the default route.

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -32,6 +32,7 @@ JOB_ROUTER_DEFAULTS = \\
     /* remove routed job if the client disappears for 48 hours or it is idle for 6 */ \\
     /*set_PeriodicRemove = (LastClientContact - time() > 48*60*60) || \\
                          (JobStatus == 1 && (time() - QDate) > 6*60);*/ \\
+    delete_PeriodicRemove = true; \\
     delete_CondorCE = true; \\
     set_RoutedJob = true; \\
     copy_environment = orig_environment; \\


### PR DESCRIPTION
A system administrator can now use a condor config file to specify the default queue and maxMemory a job should have when being submitted to the LRMS.  The user's RSL will overwrite the admin supplied values.
## Example File

The administrator may be able to specify default values by inserting the below into a config file (a file in `/etc/condor-ce/config.d/...`:

```
JOB_ROUTER_ENTRIES = \
   [ \
     GridResource = "pbs"; \
     TargetUniverse = 9; \
     name = "Local_PBS"; \
     set_default_queue = "grid"; \
     set_default_maxMemory = 2100; \
     Requirements = true; \
   ]
```

Notice the `set_default_queue` and the `set_default_maxMemory` which will be inserted into the submitted job by the job router.
