### PR TITLE
Strip off leading and trailing whitespace from classad values

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -12,7 +12,7 @@ except ImportError:
 # This is part of the classad module as of HTCondor 8.1.2
 def quote(value):
     ad = classad.ClassAd()
-    ad["foo"] = str(value)
+    ad["foo"] = str(value).strip()
     return ad.lookup("foo").__str__()
 try:
     quote = classad.quote


### PR DESCRIPTION
Hi Brian,

I noticed during my testing that the accounting groups that were added to the classad contained the arbitrary number of spaces that separated the uid and the group name.  This patch strips all leading and trailing white space for any classad value read in from uid_table.txt or extattr_table.txt.

Thanks,

Tony
