### PR TITLE
Make condor_ce_run run with the local environment like condor_run.

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -36,7 +36,7 @@ JOB_ROUTER_DEFAULTS = \\
     delete_PeriodicRemove = true; \\
     delete_CondorCE = true; \\
     set_RoutedJob = true; \\
-    copy_environment = orig_environment; \\
+    copy_environment = "orig_environment"; \\
     set_osg_environment = "@osg_environment@"; \\
     eval_set_environment = \\
         ifThenElse(orig_environment is undefined, osg_environment, \\

--- a/src/condor_ce_run
+++ b/src/condor_ce_run
@@ -27,6 +27,7 @@ log = %(log_file)s
 
 ShouldTransferFiles = YES
 WhenToTransferOutput = ON_EXIT
+getenv = True
 
 use_x509userproxy = true
 
@@ -44,6 +45,7 @@ log = %(log_file)s
 
 ShouldTransferFiles = YES
 WhenToTransferOutput = ON_EXIT
+getenv = True
 
 use_x509userproxy = true
 


### PR DESCRIPTION
Fix bug in JOB_ROUTER_DEFAULTS where the original environment attr
wasn't being copied over. The getenv changes in condor_ce_run may be unnecessary if we solve https://jira.opensciencegrid.org/browse/SOFTWARE-1538.
