### PR TITLE
TL;DR - Remove leading whitespace from accounting group names

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -99,7 +99,7 @@ def parse_extattr():
         info = line.split(" ", 1)
         if len(info) != 2:
             continue
-        results.append(info)
+        results.append( (info[0], str(info[1]).strip()) )
     return results
         
 
@@ -119,9 +119,9 @@ def parse_uids():
             continue
         try:
             uid = int(info[0])
-            results.append( (pwd.getpwuid(uid).pw_name, info[1]) )
+            results.append( (pwd.getpwuid(uid).pw_name, str(info[1]).strip()) )
         except ValueError:
-            results.append(info)
+            results.append( (info[0], str(info[1]).strip()) )
     return results
 
 def set_accounting_group():


### PR DESCRIPTION
We have the uid_table.txt and extattr_table.txt formatted for human
readability.  Example:

tiradani    group_cms

/cms/Role=production                    group_production

Previously, the line was split and the accounting group name was taken
as-is.  Now we strip leading and trailing whitespace from the accounting
group name.
