### PR TITLE
Fix condor_ce_generator -> condor_ce_config_generator rename

### DIFF
--- a/config/condor-ce-collector-generator.cron
+++ b/config/condor-ce-collector-generator.cron
@@ -1,1 +1,1 @@
-*/10 * * * * root [[ ! -f /var/lock/subsys/condor-ce-collector ]] || /usr/bin/condor_ce_generator
+*/10 * * * * root [[ ! -f /var/lock/subsys/condor-ce-collector ]] || /usr/bin/condor_ce_config_generator

--- a/src/condor-ce-collector
+++ b/src/condor-ce-collector
@@ -52,7 +52,7 @@ fi
 grep -q 'GENERATED AT' /etc/condor-ce/config.d/02-ce-auth-generated.conf &> /dev/null
 if [ $? -ne 0 ]; then
   echo "No auth configuration present; generating a new one now."
-  condor_ce_generator
+  condor_ce_config_generator
 fi
 
 start() {


### PR DESCRIPTION
Have condor-ce-collector own condor-ce directories under /var
Have condor-ce-client require grid-certificates
Add optional %gitrev macro for easier versioning of pre-release builds
Merge changelogs
