### PR TITLE
Add /usr/sbin to the PATH of the condor_ce_config_generator cronjob

### DIFF
--- a/config/condor-ce-collector-generator.cron
+++ b/config/condor-ce-collector-generator.cron
@@ -1,1 +1,1 @@
-*/10 * * * * root [[ ! -f /var/lock/subsys/condor-ce-collector ]] || /usr/bin/condor_ce_config_generator
+*/10 * * * * root [[ ! -f /var/lock/subsys/condor-ce-collector ]] || PATH="$PATH:/usr/sbin" /usr/bin/condor_ce_config_generator


### PR DESCRIPTION
Just the PATH fix for SOFTWARE-1643
