### PR TITLE
Add condor_ce_info_status to spec file

### DIFF
--- a/config/htcondor-ce.spec
+++ b/config/htcondor-ce.spec
@@ -260,6 +260,7 @@ fi
 
 %{_bindir}/condor_ce_config_val
 %{_bindir}/condor_ce_hold
+%{_bindir}/condor_ce_info_status
 %{_bindir}/condor_ce_job_router_tool
 %{_bindir}/condor_ce_off
 %{_bindir}/condor_ce_on


### PR DESCRIPTION
Needed to avoid a build failure due to unpackaged file.
