### PR TITLE
USE_SHARED_PORT defaults to true and automatically appends SHARED_PORT

### DIFF
--- a/config/03-ce-shared-port.conf
+++ b/config/03-ce-shared-port.conf
@@ -5,8 +5,6 @@
 #
 ###############################################################################
 
-USE_SHARED_PORT = true
-DAEMON_LIST = $(DAEMON_LIST), SHARED_PORT
 SHARED_PORT=/usr/libexec/condor/condor_shared_port
 
 # In HTCondor 8.3.1, all daemons default to listening on the shared port,


### PR DESCRIPTION
to DAEMON_LIST. Previously, `condor_ce_config_val DAEMON_LIST` showed
SHARED_PORT twice.
